### PR TITLE
Modernize setup to no use easy_install but pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
     include:
         - python: "2.7"
           env: TOXENV=py27,flake8
+        - python: "3.4"
+          env: TOXENV=py34,flake8
         - python: "3.5"
           env: TOXENV=py35,flake8
         - python: "3.6"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ History
 0.1.0a5 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Add requirements.txt referencing the special Click version.
+  This makes a ``pip`` installation possible.
+  [jensens]
 
 
 0.1.0a4 (2017-10-30)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include AUTHORS.rst
 include CONTRIBUTING.rst
-include HISTORY.rst
+include CHANGES.rst
 include LICENSE
 include README.rst
 include *.py

--- a/README.rst
+++ b/README.rst
@@ -20,9 +20,13 @@ Installation
 
 .. code-block:: console
 
-    $ easy_install plonecli
+  $ pip install -r https://raw.githubusercontent.com/plone/plonecli/master/requirements.txt
 
-NOTE: for now we are using a github version of the click package. As son as the next version (>6.7) is out, we will use the normal pypi versions. This does not work with pip so well, but you can use easy_install for the moment.
+
+NOTE:
+For now we are using a github version of the click package.
+As son as the next version (>6.7) is out, we will use the normal pypi versions.
+The above `requirements.txt` references the git fork used.
 
 Usage
 =====

--- a/plonecli/__init__.py
+++ b/plonecli/__init__.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
 """Top-level package for Plone CLI."""
+import pkg_resources
 
 __author__ = """Maik Derstappen"""
 __email__ = 'md@derico.de'
-__version__ = '0.1.0'
+__version__ = pkg_resources.require('plonecli')[0].version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/MrTango/click.git@master
-.[test,dev]
+plonecli

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,33 @@
+[metadata]
+name = plonecli
+version = 0.1.0a5.dev0
+description = A Plone CLI for creating Plone packages
+long_description = file: README.rst, CHANGES.rst
+keywords =
+author = Maik Derstappen
+author_email = md@derico.de
+url = https://github.com/plone/plonecli
+license = BSD License
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Natural Language :: English
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
 
 [bumpversion]
 current_version = 0.1.0
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:plonecli/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
+[bumpversion:file:setup.cfg]
+search = version = {current_version}
+replace = version = {new_version}
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -2,68 +2,40 @@
 # -*- coding: utf-8 -*-
 
 """The setup script."""
-
-from setuptools import setup, find_packages
-
-with open('README.rst') as readme_file:
-    readme = readme_file.read()
-
-with open('HISTORY.rst') as history_file:
-    history = history_file.read()
-
-requirements = [
-    'Click>=6.8a99',
-    'bobtemplates.plone>=3.0.0a3',
-    'mr.bob',
-    'zest.releaser',
-    # TODO: put package requirements here
-]
-
-setup_requirements = [
-    'pytest-runner',
-    # TODO(MrTango): put setup requirements (distutils extensions, etc.) here
-]
+from setuptools import find_packages
+from setuptools import setup
 
 test_requirements = [
     'pytest',
-    # TODO: put package test requirements here
 ]
 
 setup(
-    name='plonecli',
-    version='0.1.0a5.dev0',
-    description="A Plone CLI for creating Plone packages",
-    long_description=readme + '\n\n' + history,
-    author="Maik Derstappen",
-    author_email='md@derico.de',
-    url='https://github.com/MrTango/plonecli',
-    packages=find_packages(include=['plonecli']),
+    # metadata see setup.cfg
+    packages=find_packages('plonecli'),
     entry_points={
         'console_scripts': [
             'plonecli=plonecli.cli:cli'
         ]
     },
     include_package_data=True,
-    install_requires=requirements,
-    dependency_links=['https://github.com/MrTango/click/tarball/plonecli_010#egg=click-6.8a99'],  # NOQA E501
-    license="BSD license",
+    install_requires=[
+        'Click>=6.8a99',
+        'bobtemplates.plone>=3.0.0a3',
+        'mr.bob',
+        'setuptools',
+        'zest.releaser',
+    ],
+    extras_require={
+        'test': test_requirements,
+        'dev': [
+            'tox',
+            'zest.releaser[recommended]',
+        ],
+    },
     zip_safe=False,
     keywords='plonecli',
     scripts=['plonecli_autocomplete.sh'],
-    classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-    ],
     test_suite='tests',
     tests_require=test_requirements,
-    setup_requires=setup_requirements,
+    setup_requires=['pytest-runner'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,30 +1,32 @@
 [tox]
-envlist = {py27,py35,py36},{flake8}
+envlist = {py27,py34,py35,py36},{flake8}
 
 [travis]
 python =
-    3.6: py36
-    3.5: py35
     2.7: py27
+    3.4: py34
+    3.5: py35
+    3.6: py36
 
 [testenv:flake8]
 basepython=python
-deps=flake8
-commands=flake8 plonecli
+deps =
+    pip>=9.0.1
+    setuptools>=33.1.1
+    git+https://github.com/MrTango/click.git@master
+    flake8
+commands =
+    flake8 plonecli
 
 [testenv]
-install_command=easy_install {opts} {packages}
+deps =
+    pip>=9.0.1
+    setuptools>=33.1.1
+    git+https://github.com/MrTango/click.git@master
+    pytest
 
 setenv =
     PYTHONPATH = {toxinidir}
-deps =
+
 commands =
-    pip install -U pip
-    pip install -r {toxinidir}/requirements_dev.txt
     py.test --basetemp={envtmpdir} tests/
-
-
-; If you want to make tox run the tests with the same versions, create a
-; requirements.txt with the pinned versions and uncomment the following lines:
-; deps =
-;     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This includes
- requirements.txt usage
- minor housekeeping and setup.* modernization,
- updating test environment (tox)
- some other findings