### PR TITLE
Improve reST and accessibility of README and docs 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,6 @@ Plone CLI
 
 A Plone CLI for creating Plone packages
 
-
-* Free software: BSD license
-
 Installation
 ============
 
@@ -24,14 +21,20 @@ Installation
 
 
 NOTE:
-For now we are using a github version of the click package.
+For now we are using a GitHub version of the click package.
 As son as the next version (>6.7) is out, we will use the normal pypi versions.
+
 The above `requirements.txt` references the git fork used.
+
+Documentation
+=============
+
+Full documentation for end users can be found in the "docs" folder.
 
 Usage
 =====
 
-Available commands
+Available Commands
 ------------------
 
 .. code-block:: console
@@ -89,7 +92,7 @@ Adding Features To Your Plone Add-on
     $ plonecli add theme
 
 
-Build your package
+Build Your Package
 ------------------
 
 .. code-block:: console
@@ -105,18 +108,20 @@ This will run:
     $ ./bin/buildout
 
 in your target directory.
+
 You can always run the 3 steps explicit by using ``virtualenv``,``requirements``, ``buildout`` instead of build.
-If you want to reset your build use the ``--clean`` option on build. This will clear your virtualenv before installing the requirements and also running buildout with ``-n`` to get the newest versions.
+If you want to reset your build use the ``--clean`` option on build.
+This will clear your virtualenv before installing the requirements and also running buildout with ``-n`` to get the newest versions.
 
 
-Run your application
+Run Your Application
 --------------------
 
 .. code-block:: console
 
     $ plonecli serve
 
-Combining commands
+Combining Commands
 ------------------
 
 You can combine the steps above like this:
@@ -126,7 +131,7 @@ You can combine the steps above like this:
     $ plonecli create addon src/collective.todo build serve
 
 
-Bash auto completion
+Bash Auto Completion
 --------------------
 
 To enable auto completion plonecli provides the plonecli_autocomplete.sh script, put this into your bashrc:
@@ -174,7 +179,7 @@ or a single test:
 
     $ py.test test/ -k test_get_package_root
 
-Register your bobtemplates package for plonecli
+Register Your Bobtemplates Package For Plonecli
 -----------------------------------------------
 
 All mr.bob templates can be registered for plonecli by adding an entry_point to your setup.py.
@@ -233,3 +238,13 @@ For every template you add a line to the entry_points and define a method in the
     1. for a standalone template, the depend_on property is None
     2. for a sub template, the depend_on contains the name of the parent standalone template.
 
+Contribute
+==========
+
+- Issue Tracker: https://github.com/plone/plonecli/issues
+- Source Code: https://github.com/plone/plonecli
+
+License
+=======
+
+This project is licensed under the BSD license.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,5 @@
-Welcome to Plone CLI's documentation!
+======================================
+Welcome To Plone CLI's Documentation !
 ======================================
 
 Contents:
@@ -13,10 +14,3 @@ Contents:
    contributing
    authors
    history
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,8 +5,8 @@ Installation
 ============
 
 
-Stable release
---------------
+Stable Release
+==============
 
 To install Plone CLI, run this command in your terminal:
 
@@ -14,19 +14,15 @@ To install Plone CLI, run this command in your terminal:
 
     $ pip install plonecli
 
-This is the preferred method to install Plone CLI, as it will always install the most recent stable release. 
+This is the preferred method to install Plone CLI, as it will always install the most recent stable release.
 
-If you don't have `pip`_ installed, this `Python installation guide`_ can guide
-you through the process.
+If you don't have `pip <https://pip.pypa.io>`_ installed, this `Python installation guide <http://docs.python-guide.org/en/latest/starting/installation/>`_
+can guide you through the process.
 
-.. _pip: https://pip.pypa.io
-.. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
+From Sources
+============
 
-
-From sources
-------------
-
-The sources for Plone CLI can be downloaded from the `Github repo`_.
+The sources for Plone CLI can be downloaded from the `GitHub repo <https://github.com/MrTango/plonecli>`_.
 
 You can either clone the public repository:
 
@@ -34,7 +30,7 @@ You can either clone the public repository:
 
     $ git clone git://github.com/MrTango/plonecli
 
-Or download the `tarball`_:
+Or download the `tarball <https://github.com/MrTango/plonecli/tarball/master>`_:
 
 .. code-block:: console
 
@@ -45,7 +41,3 @@ Once you have a copy of the source, you can install it with:
 .. code-block:: console
 
     $ python setup.py install
-
-
-.. _Github repo: https://github.com/MrTango/plonecli
-.. _tarball: https://github.com/MrTango/plonecli/tarball/master


### PR DESCRIPTION
This PR fixes various accessibility issues by improving reST.
By doing so the docs (and README) are now better readable for screen-reader and easier to translate.

Further on multiple fixes for wording and qa (like GitHub in place of Github)

Improving the README by adding info about docs, etc

Consistent headings

For now that is all, there are more issues like the usage of ``include`` and creating double content and such.
But yeah this not included in this PR :)    