### PR TITLE
Call mr.bob using its API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,11 @@ History
 2.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Do not install zest.releaser with plonecli (keep for dev/tox).
+  [jensens]
 
+- Do not install virtualenv if not Python 2.7
+  [jensens]
 
 2.0 (2020-12-10)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,16 @@ History
 2.1 (unreleased)
 ----------------
 
+- Call mr.bob using its API, no longer as subprocess.
+  This ease the usage in a virtualenv.
+  [jensens]
+
 - Do not install zest.releaser with plonecli (keep for dev/tox).
   [jensens]
 
 - Do not install virtualenv if not Python 2.7
   [jensens]
+
 
 2.0 (2020-12-10)
 ----------------

--- a/plonecli/__init__.py
+++ b/plonecli/__init__.py
@@ -5,5 +5,5 @@ import pkg_resources
 
 
 __author__ = """Maik Derstappen"""
-__email__ = 'md@derico.de'
-__version__ = pkg_resources.require('plonecli')[0].version
+__email__ = "md@derico.de"
+__version__ = pkg_resources.require("plonecli")[0].version

--- a/plonecli/cli.py
+++ b/plonecli/cli.py
@@ -4,12 +4,12 @@
 from __future__ import absolute_import
 
 from click_aliases import ClickAliasedGroup
+from mrbob.cli import main as mrbobmain
 from pkg_resources import WorkingSet
 from plonecli.configure_mrbob import is_venv_disabled
 from plonecli.exceptions import NoSuchValue
 from plonecli.exceptions import NotInPackageError
 from plonecli.registry import template_registry as reg
-from mrbob.cli import main as mrbobmain
 
 import click
 import os
@@ -84,7 +84,9 @@ def create(context, template, name):
     cur_dir = os.getcwd()
     context.obj["target_dir"] = "{0}/{1}".format(cur_dir, name)
     echo(
-        "\nRUN: mrbob {0} -O {1}".format(bobtemplate, name), fg="green", reverse=True,
+        "\nRUN: mrbob {0} -O {1}".format(bobtemplate, name),
+        fg="green",
+        reverse=True,
     )
     mrbobmain([bobtemplate, "-O", name])
 

--- a/plonecli/cli.py
+++ b/plonecli/cli.py
@@ -117,7 +117,10 @@ def create_virtualenv(context, clear, upgrade, python):
     if context.obj.get("target_dir", None) is None:
         raise NotInPackageError(context.command.name)
     python_bin = python or context.obj.get("python")
-    params = [python_bin, "-m", "venv", "venv"]
+    if python_bin == "python2.7":
+        params = ["virtualenv", "-p", python_bin, "venv"]
+    else:
+        params = [python_bin, "-m", "venv", "venv"]
     if clear:
         params.append("--clear")
     if upgrade:

--- a/plonecli/cli.py
+++ b/plonecli/cli.py
@@ -9,6 +9,7 @@ from plonecli.configure_mrbob import is_venv_disabled
 from plonecli.exceptions import NoSuchValue
 from plonecli.exceptions import NotInPackageError
 from plonecli.registry import template_registry as reg
+from mrbob.cli import main as mrbobmain
 
 import click
 import os
@@ -85,7 +86,7 @@ def create(context, template, name):
     echo(
         "\nRUN: mrbob {0} -O {1}".format(bobtemplate, name), fg="green", reverse=True,
     )
-    subprocess.call(["mrbob", bobtemplate, "-O", name])
+    mrbobmain([bobtemplate, "-O", name])
 
 
 @cli.command()
@@ -101,7 +102,7 @@ def add(context, template):
             context.command.name, template, possibilities=reg.get_templates()
         )
     echo("\nRUN: mrbob {0}".format(bobtemplate), fg="green", reverse=True)
-    subprocess.call(["mrbob", bobtemplate])
+    mrbobmain([bobtemplate])
 
 
 @cli.command("venv", aliases=["virtualenv"])
@@ -114,10 +115,7 @@ def create_virtualenv(context, clear, upgrade, python):
     if context.obj.get("target_dir", None) is None:
         raise NotInPackageError(context.command.name)
     python_bin = python or context.obj.get("python")
-    if python_bin == "python2.7":
-        params = ["virtualenv", "-p", python_bin, "venv"]
-    else:
-        params = [python_bin, "-m", "venv", "venv"]
+    params = [python_bin, "-m", "venv", "venv"]
     if clear:
         params.append("--clear")
     if upgrade:

--- a/plonecli/configure_mrbob.py
+++ b/plonecli/configure_mrbob.py
@@ -66,7 +66,7 @@ def check_git_disabled(configurator, answer):
 
 
 def get_mrbob_config_variable(varname, dirname):
-    """Checks mrbob config of given variable from ~/.mrbob file """
+    """Checks mrbob config of given variable from ~/.mrbob file"""
     config = RawConfigParser()
     file_name = ".mrbob"
     config_path = dirname + "/" + file_name
@@ -166,14 +166,11 @@ package.git.disabled = {4}
         safe_string(answers["package.git.disabled"]),
     )
     if not configurator.variables["configure_mrbob.package.git.disabled"]:
-        template = (
-            template
-            + """package.git.init = {0}
+        template = template + """package.git.init = {0}
 package.git.autocommit = {1}
 """.format(
-                safe_string(answers["package.git.init"]),
-                safe_string(answers["package.git.autocommit"]),
-            )
+            safe_string(answers["package.git.init"]),
+            safe_string(answers["package.git.autocommit"]),
         )
     template = (
         template

--- a/plonecli/registry.py
+++ b/plonecli/registry.py
@@ -19,7 +19,7 @@ except ImportError:
 class BobConfig(object):
     def __init__(self):
         self.template = None
-        self.python = 'python'
+        self.python = "python"
 
 
 def read_bob_config(root_folder):
@@ -27,10 +27,10 @@ def read_bob_config(root_folder):
     if not root_folder:
         return bob_config
     config = ConfigParser()
-    path = root_folder + '/bobtemplate.cfg'
+    path = root_folder + "/bobtemplate.cfg"
     config.read(path)
     sections = {
-        'main': ['template', 'python'],
+        "main": ["template", "python"],
     }
     for section, options in sections.items():
         for option in options:
@@ -50,7 +50,7 @@ def get_package_root(cur_dir=None):
 
     :returns: root_folder or None
     """
-    file_name = 'bobtemplate.cfg'
+    file_name = "bobtemplate.cfg"
     root_folder = None
     cur_dir = cur_dir or os.getcwd()
     while True:
@@ -71,13 +71,12 @@ def get_package_root(cur_dir=None):
 
 
 class TemplateRegistry(object):
-
     def __init__(self, cur_dir=None):
         self.root_folder = get_package_root(cur_dir=cur_dir)
         self.bob_config = read_bob_config(self.root_folder)
         self.templates = {}
         self.template_infos = {}
-        for entry_point in pkg_resources.iter_entry_points('mrbob_templates'):
+        for entry_point in pkg_resources.iter_entry_points("mrbob_templates"):
             template_info_method = entry_point.load()
             self.template_infos[entry_point.name] = template_info_method()
 
@@ -85,10 +84,10 @@ class TemplateRegistry(object):
             if tmpl_info.depend_on:
                 continue
             self.templates[entry_point_name] = {
-                'template_name': tmpl_info.plonecli_alias or entry_point_name,
-                'subtemplates': {},
-                'info': tmpl_info.info,
-                'deprecated': tmpl_info.deprecated,
+                "template_name": tmpl_info.plonecli_alias or entry_point_name,
+                "subtemplates": {},
+                "info": tmpl_info.info,
+                "deprecated": tmpl_info.deprecated,
             }
 
         for entry_point_name, tmpl_info in self.template_infos.items():
@@ -96,52 +95,51 @@ class TemplateRegistry(object):
                 continue
             if tmpl_info.depend_on not in self.templates:
                 print(
-                    '{',
+                    "{",
                     'Template dependency "{0}" not found!'.format(
                         tmpl_info.depend_on,
                     ),
-                    '}',
+                    "}",
                 )
                 continue
-            self.templates[tmpl_info.depend_on][
-                'subtemplates'][entry_point_name] = tmpl_info.plonecli_alias \
-                or entry_point_name
+            self.templates[tmpl_info.depend_on]["subtemplates"][entry_point_name] = (
+                tmpl_info.plonecli_alias or entry_point_name
+            )
 
     def list_templates(self):
-        templates_str = 'Available mr.bob templates:\n'
+        templates_str = "Available mr.bob templates:\n"
         for key in sorted(self.templates.keys()):
             tmpl = self.templates[key]
-            tmpl_entry = tmpl['template_name']
-            tmpl_deprecated = tmpl.get('deprecated')
-            tmpl_info = tmpl.get('info')
+            tmpl_entry = tmpl["template_name"]
+            tmpl_deprecated = tmpl.get("deprecated")
+            tmpl_info = tmpl.get("info")
             if tmpl_deprecated:
-                tmpl_entry += ' [deprecated]'
+                tmpl_entry += " [deprecated]"
             if tmpl_info:
-                tmpl_entry += ' >> {0}'.format(tmpl_info)
-            templates_str += ' - {0}\n'.format(
+                tmpl_entry += " >> {0}".format(tmpl_info)
+            templates_str += " - {0}\n".format(
                 tmpl_entry,
             )
-            subtemplates = tmpl.get('subtemplates', [])
+            subtemplates = tmpl.get("subtemplates", [])
             for subtmpl_name in sorted(subtemplates.values()):
-                templates_str += '  - {0}\n'.format(subtmpl_name)
+                templates_str += "  - {0}\n".format(subtmpl_name)
         return templates_str
 
     def get_templates(self):
         if not self.root_folder:
-            return [tmpl['template_name'] for tmpl in self.templates.values()]
+            return [tmpl["template_name"] for tmpl in self.templates.values()]
         template = self.templates.get(self.bob_config.template)
         if not template:
             print(
-                'no subtemplates found for {0}!'.format(
+                "no subtemplates found for {0}!".format(
                     self.bob_config.template,
                 ),
             )
             return []
-        return list(template['subtemplates'].values())
+        return list(template["subtemplates"].values())
 
     def resolve_template_name(self, plonecli_alias):
-        """ resolve template name from plonecli alias
-        """
+        """resolve template name from plonecli alias"""
         template_name = None
         for entry_point, tmpl_info in self.template_infos.items():
             if tmpl_info.plonecli_alias == plonecli_alias:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,40 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
+[options]
+python_requires = >=3.6
+install_requires=
+    setuptools
+    Click>=7.0
+    click-aliases
+    mr.bob
+    bobtemplates.plone>=5.2.0
+tests_require =
+    pytest
+    isort>=5.0.0   
+test_suite = tests
+zip_safe = False
+include_package_data = True
+setup_requires = pytest-runner
+scripts = plonecli_autocomplete.sh
+
+[options.extras_require]
+test =
+    pytest
+    isort>=5.0.0
+    flake8
+dev =
+    tox
+    zest.releaser[recommended]
+    
+[options.packages.find]
+where =
+    src
+
+[options.entry_points]
+console_scripts =
+    plonecli = plonecli.cli:cli
+
 [bumpversion]
 current_version = 0.1.1
 commit = True

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,10 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "setuptools",
-        "virtualenv",
+        'virtualenv;python_version<"3"',
         "Click>=7.0",
         "click-aliases",
         "mr.bob",
-        "zest.releaser",
         "bobtemplates.plone>=5.2.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,9 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """The setup script."""
-from __future__ import absolute_import
-
-from setuptools import find_packages
 from setuptools import setup
 
 
-test_requirements = [
-    "pytest",
-    "isort>=5.0.0",
-]
-
 setup(
-    # metadata see setup.cfg
-    packages=find_packages(include=["plonecli"]),
-    entry_points={"console_scripts": ["plonecli=plonecli.cli:cli"]},
-    include_package_data=True,
-    python_requires=">=3.6",
-    install_requires=[
-        "setuptools",
-        'virtualenv;python_version<"3"',
-        "Click>=7.0",
-        "click-aliases",
-        "mr.bob",
-        "bobtemplates.plone>=5.2.0",
-    ],
-    extras_require={
-        "test": test_requirements,
-        "dev": ["tox", "zest.releaser[recommended]"],
-    },
-    zip_safe=False,
-    keywords="plonecli",
-    scripts=["plonecli_autocomplete.sh"],
-    test_suite="tests",
-    tests_require=test_requirements,
-    setup_requires=["pytest-runner"],
+    # see setup.cfg
 )

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,6 @@ deps =
     # Useful flake8 plugins that are Python and Plone specific:
     isort
     flake8-blind-except
-    flake8-coding
     flake8-commas
     flake8-debugger
     flake8-deprecated


### PR DESCRIPTION
Call mr.bob using its API, no longer as subprocess. This ease the usage in a virtualenv.

Also minr cleanup ins `setup.py`:

- Do not install zest.releaser with plonecli (keep for dev/tox).
- Do not install virtualenv if not Python 2.7
