### PR TITLE
Remove dependency on virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ target/
 /tmpdist
 /_build
 /venv
+pyvenv.cfg
+
+.settings/
+.*project

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ History
 2.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Remove dependency on ``virtualenv``.
+  [wesleybl]
 
 
 2.1.2 (2021-05-06)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "setuptools",
-        'virtualenv;python_version<"3"',
         "Click>=7.0",
         "click-aliases",
         "mr.bob",


### PR DESCRIPTION
`virtualenv` was only installed on Python 2. But now the package no longer supports Python 2. See:

https://github.com/plone/plonecli/blob/8bebc4c5108fb48bf00c7401e8fc3665b730d192/setup.py#L21
