### PR TITLE
Rename autocompletion parameter to shell_complete to fix #74 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ History
 - Remove dependency on ``virtualenv``.
   [wesleybl]
 
+- Rename deprecated ``autocompletion`` parameter to ``shell_complete``
+  [zshashz]
+
 
 2.1.2 (2021-05-06)
 ------------------

--- a/plonecli/cli.py
+++ b/plonecli/cli.py
@@ -71,7 +71,7 @@ def cli(context, list_templates, versions):
 
 
 @cli.command()
-@click.argument("template", type=click.STRING, autocompletion=get_templates)
+@click.argument("template", type=click.STRING, shell_complete=get_templates)
 @click.argument("name")
 @click.pass_context
 def create(context, template, name):
@@ -92,7 +92,7 @@ def create(context, template, name):
 
 
 @cli.command()
-@click.argument("template", type=click.STRING, autocompletion=get_templates)
+@click.argument("template", type=click.STRING, shell_complete=get_templates)
 @click.pass_context
 def add(context, template):
     """Add features to your existing Plone package"""


### PR DESCRIPTION
In the [click changelog](https://click.palletsprojects.com/en/8.1.x/changes/)
- autocompletion parameter to Command is renamed to shell_complete.

So, I renamed the instances of the autocompletion parameter to shell_complete in cli.py. This solves Issue #74 
