### PR TITLE
test in additional python versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: [3.7, 3.8, 3.9, '3.10']
+                python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+                python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,12 +15,12 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
+                python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ universal = 1
 
 [flake8]
 exclude = docs,tmp,tmpdist,local,lib,build,bin,dist,include,man
-ignore =  W503, C812, E501, T001  # E203, E266
+ignore =  W503, C812, E501, T001
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B


### PR DESCRIPTION
We have seen some errors when running plonecli with Python 3.12, so let's test it here.

```
plonecli is already on your PATH and installed at /home/lur/.local/bin/plonecli. Downloading and running anyway.
Traceback (most recent call last):
  File "/home/lur/.local/pipx/.cache/8907bfa6381e38c/bin/plonecli", line 5, in <module>
    from plonecli.cli import cli
  File "/home/lur/.local/pipx/.cache/8907bfa6381e38c/lib/python3.12/site-packages/plonecli/__init__.py", line 4, in <module>
    import pkg_resources
  File "/home/lur/.local/pipx/shared/lib/python3.11/site-packages/pkg_resources/__init__.py", line 2191, in <module>
    register_finder(pkgutil.ImpImporter, find_on_path)
                    ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
make: *** [Makefile:148: add] Error 1

```