### PR TITLE
Prefer installed plonecli over uvx in skill invoke docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,11 @@
 ## 7.0.0b9 (unreleased)
 
 
-- Nothing changed yet.
+- Prefer the installed `plonecli` (on `PATH`, e.g. via `uv tool install
+  plonecli`) over `uvx` in the skill's invoke docs, so the user's
+  installed/pinned version runs instead of a separate PyPI-resolved copy.
+  `uvx` is now documented as a no-install fallback.
+  [MrTango]
 
 
 ## 7.0.0b8 (2026-05-24)

--- a/plonecli/skills/plonecli/SKILL.md
+++ b/plonecli/skills/plonecli/SKILL.md
@@ -9,7 +9,8 @@ description: Scaffold and develop Plone packages with plonecli (copier-template 
 
 ## How to invoke it
 
-- **End users:** `uvx plonecli <command>` (no install needed).
+- **Installed (preferred):** `plonecli <command>` — if `plonecli` is on `PATH` (e.g. via `uv tool install plonecli`), always use the bare command so the user's installed/pinned version runs.
+- **Not installed / one-off:** `uvx plonecli <command>` (no install needed). Only fall back to this when `plonecli` is not on `PATH`.
 - **Inside this repo (plonecli's own source):** it is not on `PATH` — use `uv run plonecli <command>`.
 
 On first run, plonecli clones the copier-templates to `~/.copier-templates/plone-copier-templates`. If a command complains about missing templates, run `plonecli update` first.


### PR DESCRIPTION
The skill's invoke section led with 'uvx plonecli', which runs a separate PyPI-resolved copy and ignores a version installed via 'uv tool install plonecli'. Make the bare 'plonecli' command (on PATH) the preferred form and demote uvx to a no-install fallback.

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

