### PR TITLE
Fix devcontainer copier-templates mount and $HOME build warning

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -82,7 +82,7 @@ USER node
 
 # Install global packages
 ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
-ENV PATH=$HOME/.local/bin:$PATH:/usr/local/share/npm-global/bin
+ENV PATH=/home/node/.local/bin:$PATH:/usr/local/share/npm-global/bin
 
 # Set the default shell to zsh rather than sh
 ENV SHELL=/bin/zsh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
 
-	"initializeCommand": "mkdir -p \"$HOME/.claude\" \"$HOME/.copier-templates\"",
+	"initializeCommand": "mkdir -p \"$HOME/.claude\" \"$HOME/develop/plone/src/copier-templates\"",
 	"runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
 	"customizations": {
 		"vscode": {
@@ -48,8 +48,7 @@
 		"source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
 		"source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
 		"source=${localEnv:HOME}/.claude,target=/host-claude-config,type=bind,readonly",
-		"source=${localEnv:HOME}/.copier-templates,target=/home/node/.copier-templates,type=bind,readonly",
-		"source=${localEnv:HOME}/develop/plone/src/copier-templates,target=/home/node/develop/plone/src/copier-templates,type=bind,consistency=delegated"
+		"source=${localEnv:HOME}/develop/plone/src/copier-templates,target=/home/node/.copier-templates/plone-copier-templates,type=bind,consistency=delegated"
 	],
 	"containerEnv": {
 		"CLAUDE_CONFIG_DIR": "/home/node/.claude",


### PR DESCRIPTION
- Use a single read-write bind of the host dev clone (~/develop/plone/src/copier-templates) into the path plonecli reads (~/.copier-templates/plone-copier-templates), replacing the broken non-existent mount and the redundant readonly mount.
- Update initializeCommand to ensure the dev path exists.
- Use explicit /home/node instead of undefined $HOME in Dockerfile PATH.

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

